### PR TITLE
Set _reader and _writer to None on exit, and remove _auth

### DIFF
--- a/async_mcrcon.py
+++ b/async_mcrcon.py
@@ -14,7 +14,6 @@ class MinecraftClient:
         self.port = port
         self.password = password
 
-        self._auth = None
         self._reader = None
         self._writer = None
 
@@ -28,11 +27,11 @@ class MinecraftClient:
     async def __aexit__(self, exc_type, exc, tb):
         if self._writer:
             self._writer.close()
+            self._reader = None
+            self._writer = None
 
     async def _authenticate(self):
-        if not self._auth:
-            await self._send(3, self.password)
-            self._auth = True
+        await self._send(3, self.password)
 
     async def _read_data(self, leng):
         data = b''

--- a/async_mcrcon.py
+++ b/async_mcrcon.py
@@ -27,6 +27,7 @@ class MinecraftClient:
     async def __aexit__(self, exc_type, exc, tb):
         if self._writer:
             self._writer.close()
+            await self._writer.wait_closed()
             self._reader = None
             self._writer = None
 


### PR DESCRIPTION
• Make sure it closes properly
• Remove _auth because we should always send the password when trying to connect

This fixes a bug where it would send once, then not again after